### PR TITLE
Use dispmanx scaling

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -622,6 +622,14 @@ extern "C" {
 #define SDL_HINT_NO_SIGNAL_HANDLERS   "SDL_NO_SIGNAL_HANDLERS"
 
 /**
+ *  \brief Tell dispmanx to stretch the SDL window to fill the display.
+ *
+ * This hint only applies to the rpi video driver.
+ *
+ */
+#define SDL_HINT_RPI_STRETCH_WINDOW    "SDL_HINT_RPI_STRETCH_WINDOW"
+
+/**
  *  \brief Tell SDL not to generate window-close events for Alt+F4 on Windows.
  *
  * The variable can be set to the following values:

--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -636,6 +636,15 @@ extern "C" {
 #define SDL_HINT_VIDEO_RPI_SCALE_MODE    "SDL_VIDEO_RPI_SCALE_MODE"
 
 /**
+ *  \brief Tell dispmanx to set an specific aspect ratio.
+ *
+ * This hint only applies to the rpi video driver.
+ *
+ * Must be set together with SDL_HINT_VIDEO_RPI_SCALE_MODE=1.
+ */
+#define SDL_HINT_VIDEO_RPI_RATIO    "SDL_VIDEO_RPI_RATIO"
+
+/**
  *  \brief Tell SDL not to generate window-close events for Alt+F4 on Windows.
  *
  * The variable can be set to the following values:

--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -626,8 +626,14 @@ extern "C" {
  *
  * This hint only applies to the rpi video driver.
  *
+ * The variable can be set to the following values:
+ *   "0"       - Window resolution is desktop resolution.
+ *               This is the behaviour of SDL <= 2.0.4. (default)
+ *   "1"       - Requested video resolution will be scaled to desktop resolution.
+ *               Aspect ratio of requested video resolution will be respected.
+ *   "2"       - Requested video resolution will be scaled to desktop resolution.
  */
-#define SDL_HINT_RPI_STRETCH_WINDOW    "SDL_HINT_RPI_STRETCH_WINDOW"
+#define SDL_HINT_VIDEO_RPI_SCALE_MODE    "SDL_VIDEO_RPI_SCALE_MODE"
 
 /**
  *  \brief Tell SDL not to generate window-close events for Alt+F4 on Windows.

--- a/src/video/raspberry/SDL_rpivideo.c
+++ b/src/video/raspberry/SDL_rpivideo.c
@@ -215,7 +215,8 @@ RPI_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode)
 int
 RPI_CreateWindow(_THIS, SDL_Window * window)
 {
-    const char *hint = SDL_GetHint(SDL_HINT_VIDEO_RPI_SCALE_MODE);
+    const char *hintScale = SDL_GetHint(SDL_HINT_VIDEO_RPI_SCALE_MODE);
+    const char *hintRatio = SDL_GetHint(SDL_HINT_VIDEO_RPI_RATIO);
     char scalemode = '0';
     SDL_WindowData *wdata;
     SDL_VideoDisplay *display;
@@ -241,15 +242,21 @@ RPI_CreateWindow(_THIS, SDL_Window * window)
     float srcAspect = 1; 
     float dstAspect = 1;
 
-    if (hint != NULL)
-        scalemode = *hint;
+    if (hintScale != NULL)
+        scalemode = *hintScale;
 
     /* Create a dispman element and associate a window to it */
     switch(scalemode) {
         case '1':
             /* Fullscreen mode. */
             /* Calculate source and destination aspect ratios. */
-            srcAspect = (float)window->w / (float)window->h;
+            if (hintRatio != NULL) 
+                srcAspect = strtof(hintRatio, NULL);
+            else
+                srcAspect = (float)window->w / (float)window->h; 
+            /* only allow sensible aspect ratios */
+            if (srcAspect < 0.2f || srcAspect > 6.0f)
+                srcAspect = (float)window->w / (float)window->h;
             dstAspect = (float)display->desktop_mode.w / (float)display->desktop_mode.h;
             /* If source and destination aspect ratios are not equal correct destination width. */
             if (srcAspect < dstAspect) {


### PR DESCRIPTION
Inspired by @loganmc10's SDL2 patch https://bugzilla.libsdl.org/show_bug.cgi?id=3353 and this thread https://github.com/RetroPie/RetroPie-Setup/issues/1511 i have modified SDL_rpivideo.c.

The video driver upscale window resolution to desktop resolution if necessary. Video aspect will be kept. Window will be centered. Stretch window to fullscreen (ignore aspect) can be enabled with new SDL hint „SDL_HINT_RPI_STRETCH_WINDOW“.

This change allows graphics intensive applications like mupen64plus/GlideN64 to run at a lower resolution which leads to better performance. It is no longer necessary to switch display resolution to get better performance.

This modification was tested with emulationstation and mupen64plus. Mupen64plus module must be modified if this PR will be commited (set GlideN64 as default video plugin, force 320x240 render resolution, use windowed mode).
