### PR TITLE
gcc5 fix (Ubuntu 16.04 on ODROID-C1)

### DIFF
--- a/src/video/mali-fbdev/SDL_malivideo.c
+++ b/src/video/mali-fbdev/SDL_malivideo.c
@@ -119,17 +119,17 @@ MALI_VideoInit(_THIS)
     SDL_VideoDisplay display;
     SDL_DisplayMode current_mode;
     SDL_DisplayData *data;
+    int fd = open("/dev/fb0", O_RDWR, 0);
+    struct fb_var_screeninfo vinfo;
 
     data = (SDL_DisplayData *) SDL_calloc(1, sizeof(SDL_DisplayData));
     if (data == NULL) {
         return SDL_OutOfMemory();
     }
 
-    int fd = open("/dev/fb0", O_RDWR, 0);
     if (fd < 0) {
         return SDL_SetError("mali-fbdev: Could not open framebuffer device");
     }
-    struct fb_var_screeninfo vinfo;
     if (ioctl(fd, FBIOGET_VSCREENINFO, &vinfo) < 0) {
         MALI_VideoQuit(_this);
         return SDL_SetError("mali-fbdev: Could not get framebuffer information");


### PR DESCRIPTION
Fix to enable SDL2.0.5+mali to build on Ubuntu 16.04 running on HardKernel ODROID-C1.