### PR TITLE
Raspberry Pi: Fix ES1/PVR & implement VC4 autodetect

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,7 @@ confflags = --disable-rpath --disable-video-directfb \
             --disable-x11-shared  --disable-video-opengl --enable-video-opengles \
             --disable-esd --disable-pulseaudio \
             --disable-input-tslib \
-            --enable-video-rpi
+            --enable-video-rpi --enable-video-kmsdrm
 
 %:
 	dh $@ --parallel

--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -44,12 +44,12 @@
 
 #if SDL_VIDEO_DRIVER_RPI
 /* Raspbian places the OpenGL ES/EGL binaries in a non standard path */
-#define DEFAULT_EGL "/opt/vc/lib/libbrcmEGL.so"
-#define DEFAULT_OGL_ES2 "/opt/vc/lib/libbrcmGLESv2.so"
-#define ALT_EGL "/opt/vc/lib/libEGL.so"
-#define ALT_OGL_ES2 "/opt/vc/lib/libGLESv2.so"
-#define DEFAULT_OGL_ES_PVR "/opt/vc/lib/libGLES_CM.so"
-#define DEFAULT_OGL_ES "/opt/vc/lib/libGLESv1_CM.so"
+#define DEFAULT_EGL ( vc4 ? "libEGL.so" : "/opt/vc/lib/libbrcmEGL.so" )
+#define DEFAULT_OGL_ES2 ( vc4 ? "libGLESv2.so.2" : "/opt/vc/lib/libbrcmGLESv2.so" )
+#define ALT_EGL ( vc4 ? "libEGL.so" : "/opt/vc/lib/libEGL.so" )
+#define ALT_OGL_ES2 ( vc4 ? "libGLESv2.so.2" : "/opt/vc/lib/libGLESv2.so" )
+#define DEFAULT_OGL_ES_PVR ( vc4 ? "libGLES_CM.so.1" : "/opt/vc/lib/libbrcmGLESv2.so" )
+#define DEFAULT_OGL_ES ( vc4 ? "libGLESv1_CM.so.1" : "/opt/vc/lib/libbrcmGLESv2.so" )
 
 #elif SDL_VIDEO_DRIVER_ANDROID || SDL_VIDEO_DRIVER_VIVANTE
 /* Android */
@@ -255,6 +255,9 @@ SDL_EGL_LoadLibrary(_THIS, const char *egl_path, NativeDisplayType native_displa
     int egl_version_major = 0, egl_version_minor = 0;
 #if SDL_VIDEO_DRIVER_WINDOWS || SDL_VIDEO_DRIVER_WINRT
     const char *d3dcompiler;
+#endif
+#if SDL_VIDEO_DRIVER_RPI
+    SDL_bool vc4 = (0 == access("/sys/module/vc4/", F_OK));
 #endif
 
     if (_this->egl_data) {

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -97,11 +97,11 @@ static VideoBootStrap *bootstrap[] = {
 #if SDL_VIDEO_DRIVER_PSP
     &PSP_bootstrap,
 #endif
-#if SDL_VIDEO_DRIVER_RPI
-    &RPI_bootstrap,
-#endif 
 #if SDL_VIDEO_DRIVER_KMSDRM
     &KMSDRM_bootstrap,
+#endif
+#if SDL_VIDEO_DRIVER_RPI
+    &RPI_bootstrap,
 #endif
 #if SDL_VIDEO_DRIVER_NACL
     &NACL_bootstrap,


### PR DESCRIPTION
Fix ES1/PVR, implement VC4 autodetect and change bootstrap priority of KMSDRM driver so that both drivers can work correctly with the same SDL2 build.