### PR TITLE
Enable OpenGL support on KMS branch

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 confflags = --disable-rpath --disable-video-directfb \
             --disable-nas --disable-esd --disable-arts \
             --disable-alsa-shared --disable-pulseaudio \
-            --disable-x11-shared --disable-video-opengl --disable-video-rpi \
+            --disable-x11-shared --enable-video-opengl --disable-video-rpi \
             --enable-video-kmsdrm
 
 %:


### PR DESCRIPTION
There's no reason to disable OpenGL support, especially considering that the vc4/v3d driver (mostly?) supports OpenGL 2.1.