### PR TITLE
Modesetting support for KMSDRM driver

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmsym.h
+++ b/src/video/kmsdrm/SDL_kmsdrmsym.h
@@ -61,7 +61,7 @@ SDL_KMSDRM_SYM(drmModeConnectorPtr,drmModeGetConnector,(int fd, uint32_t connect
 SDL_KMSDRM_SYM(int,drmHandleEvent,(int fd,drmEventContextPtr evctx))
 SDL_KMSDRM_SYM(int,drmModePageFlip,(int fd, uint32_t crtc_id, uint32_t fb_id,
                                     uint32_t flags, void *user_data))
-
+SDL_KMSDRM_SYM(int,drmSetClientCap,(int fd, uint64_t capability, uint64_t value))
 
 SDL_KMSDRM_MODULE(GBM)
 SDL_KMSDRM_SYM(int,gbm_device_get_fd,(struct gbm_device *gbm))

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -417,6 +417,9 @@ KMSDRM_VideoInit(_THIS)
         goto cleanup;
     }
 
+    /* Expose aspect ratio flags to userspace */
+    KMSDRM_drmSetClientCap(vdata->drm_fd, DRM_CLIENT_CAP_ASPECT_RATIO, 1);
+
     /* Find the first available connector with modes */
     resources = KMSDRM_drmModeGetResources(vdata->drm_fd);
     if (!resources) {


### PR DESCRIPTION
Add patches that allow modesetting via the KMSDRM driver via environment variables (`SDL_VIDEO_KMSDRM_CRTCID`, `SDL_VIDEO_KMSDRM_MODEID`, `SDL_VIDEO_KMSDRM_MODELINE`), and unlock aspect ratio flag decoding via DRM so that all possible modes are exposed to the KMSDRM driver.