### PR TITLE
kmsdrm: enable aspect ratio support

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -417,8 +417,10 @@ KMSDRM_VideoInit(_THIS)
         goto cleanup;
     }
 
-    /* Expose aspect ratio flags to userspace */
+#ifdef DRM_CLIENT_CAP_ASPECT_RATIO
+    /* Expose aspect ratio flags to userspace if available */
     KMSDRM_drmSetClientCap(vdata->drm_fd, DRM_CLIENT_CAP_ASPECT_RATIO, 1);
+#endif
 
     /* Find the first available connector with modes */
     resources = KMSDRM_drmModeGetResources(vdata->drm_fd);


### PR DESCRIPTION
Minor change to #16 including an #ifdef for compatibility with older drm headers (eg on stretch).

Add patches that allow modesetting via the KMSDRM driver via environment variables (SDL_VIDEO_KMSDRM_CRTCID, SDL_VIDEO_KMSDRM_MODEID, SDL_VIDEO_KMSDRM_MODELINE), and unlock aspect ratio flag decoding via DRM so that all possible modes are exposed to the KMSDRM driver.