### PR TITLE
only enable DRM_CLIENT_CAP_ASPECT_RATIO cap if it's available in the …

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -417,8 +417,10 @@ KMSDRM_VideoInit(_THIS)
         goto cleanup;
     }
 
-    /* Expose aspect ratio flags to userspace */
+#ifdef DRM_CLIENT_CAP_ASPECT_RATIO
+    /* Expose aspect ratio flags to userspace if available */
     KMSDRM_drmSetClientCap(vdata->drm_fd, DRM_CLIENT_CAP_ASPECT_RATIO, 1);
+#endif
 
     /* Find the first available connector with modes */
     resources = KMSDRM_drmModeGetResources(vdata->drm_fd);


### PR DESCRIPTION
…drm headers

 * not available on stretch so it broke building